### PR TITLE
Linux DCP Boundary support

### DIFF
--- a/src/device/pf_block_reader.c
+++ b/src/device/pf_block_reader.c
@@ -1066,6 +1066,25 @@ void pf_get_port_data_adjust_peer_to_peer_boundary (
    p_boundary->adjust_properties = pf_get_uint16 (p_info, p_pos);
 }
 
+void pf_get_port_data_adjust_dcp_boundary (
+   pf_get_info_t * p_info,
+   uint16_t * p_pos,
+   pf_adjust_dcp_boundary_t * p_boundary)
+{
+   uint8_t dummy[4];
+   uint32_t temp;
+
+   memset (p_boundary, 0, sizeof (*p_boundary));
+
+   pf_get_mem (p_info, p_pos, 2, dummy); /* Padding */
+
+   temp = pf_get_uint32 (p_info, p_pos);
+   p_boundary->dcp_boundary.do_not_send_dcp_ident = pf_get_bits (temp, 0, 1);
+   p_boundary->dcp_boundary.do_not_send_dcp_hello = pf_get_bits (temp, 1, 1);
+
+   p_boundary->adjust_properties = pf_get_uint16 (p_info, p_pos);
+}
+
 void pf_get_interface_adjust (
    pf_get_info_t * p_info,
    uint16_t * p_pos,

--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -394,6 +394,17 @@ void pf_get_port_data_adjust_peer_to_peer_boundary (
    pf_adjust_peer_to_peer_boundary_t * boundary);
 
 /**
+ * Extract a AdjustDCPBoundary data block from a buffer.
+ * @param p_info           InOut: The parser information.
+ * @param p_pos            InOut: The current parsing position.
+ * @param boundary         Out:   Destination structure.
+ */
+void pf_get_port_data_adjust_dcp_boundary (
+   pf_get_info_t * p_info,
+   uint16_t * p_pos,
+   pf_adjust_dcp_boundary_t * p_boundary);
+
+/**
  * Extract a pd interface adjust block from a buffer.
  *
  * @param p_info           InOut: The parser information.

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -851,6 +851,24 @@ void pf_put_pdport_data_adj_p2pb (
    uint16_t * p_pos);
 
 /**
+ * Insert PDport data adjust block into buffer
+ *
+ * @param is_big_endian   In:    Endianness of the destination buffer.
+ * @param subslot         In:    DAP subslot identifying the port.
+ * @param p_dcp_boundary  In:    DCP boundary
+ * @param res_len         In:    Size of destination buffer.
+ * @param p_bytes         Out:   Destination buffer.
+ * @param p_pos           InOut: Position in destination buffer.
+ */
+void pf_put_pdport_data_adj_dcp_boundary (
+   bool is_big_endian,
+   uint16_t subslot,
+   const pf_adjust_dcp_boundary_t * p_dcp_boundary,
+   uint16_t res_len,
+   uint8_t * p_bytes,
+   uint16_t * p_pos);
+
+/**
  * Insert PDport data adjust block into a buffer.
  *
  * @param is_big_endian             In:    Endianness of the destination buffer.

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -546,6 +546,7 @@ typedef enum pf_block_type_values
    PF_BT_ADJUST_MAU_TYPE = 0x020E,
    PF_BT_ADJUST_LINK_STATE = 0x021B,
    PF_BT_ADJUST_PEER_TO_PEER_BOUNDARY = 0x0224,
+   PF_BT_ADJUST_DCP_BOUNDARY = 0x0225,
    PF_BT_INTERFACE_REAL_DATA = 0x0240,
    PF_BT_INTERFACE_ADJUST = 0x0250,
    PF_BT_PORT_STATISTICS = 0x0251,
@@ -2818,6 +2819,21 @@ typedef struct pf_peer_to_peer_boundary
    uint32_t reserved : 29;
 } pf_peer_to_peer_boundary_t;
 
+/* Used by pf_pdport_dcp_boundary() */
+#define PF_PDPORT_DCP_IDENT_TYPE  0x00
+#define PF_PDPORT_DCP_HELLO_TYPE  0x01
+
+/**
+ * Substitution name: DCPBoundary
+ * PN-AL-protocol (Jun22) Table 840
+ */
+typedef struct pf_dcp_boundary
+{
+   uint32_t do_not_send_dcp_ident : 1; /* 1: filter DCP Ident 01:0e:cf:00:00:00 */
+   uint32_t do_not_send_dcp_hello : 1; /* 1: filter DCP Hello 01:0e:cf:00:00:01 */
+   uint32_t reserved : 30;
+} pf_dcp_boundary_t;
+
 /**
  * Substitution name: AdjustPeerToPeerBoundary
  * BlockHeader, Padding, Padding, PeerToPeerBoundary, AdjustProperties,
@@ -2830,9 +2846,22 @@ typedef struct pf_port_data_adjust_peer_to_peer_boundary
                                   Ch.5.2.13.14 */
 } pf_adjust_peer_to_peer_boundary_t;
 
+/**
+ * Substitution name: AdjustDCPBoundary
+ * BlockHeader, Padding, Padding, DCPBoundary, AdjustProperties,
+ * [Padding*]
+ */
+typedef struct pf_port_data_adjust_dcp_boundary
+{
+   pf_dcp_boundary_t dcp_boundary;
+   uint16_t adjust_properties; /* Always 0, See PN-AL-protocol (Mar20)
+                                  Ch.5.2.13.14 */
+} pf_adjust_dcp_boundary_t;
+
 #define PF_PDPORT_ADJUST_MAUT_MASK  0x01
 #define PF_PDPORT_ADJUST_LINK_MASK  0x02
 #define PF_PDPORT_ADJUST_P2PB_MASK  0x04
+#define PF_PDPORT_ADJUST_DCPB_MASK  0x08
 
 typedef struct pf_pdport
 {
@@ -2849,6 +2878,7 @@ typedef struct pf_pdport
       pnal_eth_mau_t speed;
       pf_adjust_link_state_t link_state;
       pf_adjust_peer_to_peer_boundary_t peer_to_peer_boundary;
+      pf_adjust_dcp_boundary_t dcp_boundary;
    } adjust;
 } pf_pdport_t;
 


### PR DESCRIPTION
This is a Linux-only "hack" to add support for DCP Boundary.  It's a hack in the sense that it hard-codes a concept of a bridge, named `br0`, and adds a local Linux-specific `pf_systemf()` helper function.

For upstreaming, this needs to be refactored into properly using PNAL, which is a bit too much for work our (time boxed) purposes.  End customer only needs Linux support.