### PR TITLE
Bump file version after DCP Boundary change

### DIFF
--- a/src/common/pf_file.c
+++ b/src/common/pf_file.c
@@ -39,7 +39,7 @@
 #define PF_FILE_MAGIC 0x504E4554U /* "PNET" */
 
 /* Increase every time the saved contents have another format */
-#define PF_FILE_VERSION 0x00000001U
+#define PF_FILE_VERSION 0x00000002U
 
 /* The configurable constant PNET_MAX_FILENAME_SIZE should be at least
  * as large as the longest filename used, including termination.


### PR DESCRIPTION
With the addition of DCP Boundary support we effectively have a change in the struct size vs any previously saved on-disk file representation so we need to bump the version to prevent pf_file_load() from loading an invalid file to our new struct format.