### PR TITLE
Set Socket priority using SO_PRIORITY

### DIFF
--- a/src/ports/linux/pnal_eth.c
+++ b/src/ports/linux/pnal_eth.c
@@ -126,6 +126,26 @@ pnal_eth_handle_t * pnal_eth_init (
       return NULL;
    }
 
+   /**
+    * According to IEEE 802.1p, network traffic can be classified into 
+    * different priority levels to provide Quality of Service (QoS). 
+    * In this case, we set the priority level to 6, which corresponds 
+    * to the "Internetwork Control" traffic class. This level is used 
+    * for critical network control traffic that must be prioritized 
+    * above regular application traffic. By setting the socket priority 
+    * to 6 using the SO_PRIORITY option, we ensure that PROFINET Real-Time 
+    * (RT) frames are transmitted with high priority.
+    */
+   int priority = 6;
+   ret = setsockopt(handle->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
+   if (ret == -1)
+   {
+      LOG_WARNING (
+         PF_PNAL_LOG,
+         "PNAL(%d): failed setting socket priority, errno %d\n",
+         __LINE__, errno);
+   }
+
    /* Adjust send timeout */
    timeout.tv_sec = 0;
    timeout.tv_usec = 1;


### PR DESCRIPTION
Set socket priority using SO_PRIORITY.

This code update is essential for passing the Security Level 1 tests. The main challenge addressed by this update is the generation of significant traffic to create congestion (overload) for the switch. The previous issue was that traffic originating from the CPU (via the dsa0 port) consistently had priority zero (the lowest). Consequently, the switch could not respond to the PROFINET controller, leading to a loss of communication with the switch. The switch was expected to communicate with the controller by sending messages with higher priority.

The PR ensures that all DCP frames generated by the P-Net stack have elevated priority compared to normal traffic. Not higher than 6, to not cause interruptions on level 7, where MRP and other network control protocols reside.

- For external switch ports, using the 'dcb app' command to configure the ports to pass all PROFINET packets (ethertype 0x8892) on priority 6 was sufficient.
- For the internal port 'dsa0', which transmits messages from the CPU, the same principle cannot be directly applied. Therefore, the application needs to create a socket and set the socket priority to priority 6 using the 'setsockopt' and 'SO_PRIORITY' option.